### PR TITLE
feat(profile): 'Edit my answers' button + greyed completed banner

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -164,6 +164,7 @@ const T = {
     detailedCta: "Compléter mon profil",
     detailedReward: "+100 points",
     detailedDone_: "Questionnaire complété ✓",
+    editAnswers: "Éditer mes réponses",
     favFilms: "3 films ou séries préférés",
     favFilmsPh: "ex: Crash Landing on You, Reply 1988, Parasite",
     favMusic: "3 chanteurs ou chansons préférés",
@@ -330,6 +331,7 @@ const T = {
     detailedCta: "Complete my profile",
     detailedReward: "+100 points",
     detailedDone_: "Questionnaire completed ✓",
+    editAnswers: "Edit my answers",
     favFilms: "3 favorite films or series",
     favFilmsPh: "e.g. Crash Landing on You, Reply 1988, Parasite",
     favMusic: "3 favorite singers or songs",
@@ -2782,10 +2784,13 @@ function AppInner() {
                 </button>
               )}
               {data.profile?.detailedDone && !showDetailed && (
-                <button onClick={() => setShowDetailed(true)}
-                  style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px", borderRadius: 10, border: `1px solid ${C.okB}`, background: C.okBg, cursor: "pointer", fontFamily: "'Plus Jakarta Sans'", fontSize: 12.5, color: C.ok, width: "100%" }}>
-                  ✓ {t.detailedDone_}
-                </button>
+                <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 14px", borderRadius: 10, border: `1px solid ${C.border}`, background: C.s1 }}>
+                  <span style={{ flex: 1, fontSize: 12.5, color: C.txtS }}>✓ {t.detailedDone_}</span>
+                  <button onClick={() => setShowDetailed(true)}
+                    style={{ flexShrink: 0, padding: "6px 12px", borderRadius: 8, border: `1px solid ${C.borderS}`, background: C.s0, cursor: "pointer", fontFamily: "'Plus Jakarta Sans'", fontSize: 12, fontWeight: 500, color: C.txtS }}>
+                    {t.editAnswers}
+                  </button>
+                </div>
               )}
 
               {/* Detailed questionnaire form */}


### PR DESCRIPTION
## What
In **Mon profil**, once the detailed questionnaire is completed:
- **Before:** a bright green banner "✓ Questionnaire complété ✓" that you clicked directly to re-edit.
- **After:** the banner is now a **muted grey status row**, and re-editing is done via a dedicated **"Éditer mes réponses"** button next to it.

## Why
The green banner drew too much attention and it wasn't obvious the whole bar was clickable. Editing is now an explicit, clearly-labeled action, and the completed state recedes visually.

## Details
- Added translation key `editAnswers` (FR: "Éditer mes réponses", EN: "Edit my answers").
- Swapped the green (`C.ok`/`C.okBg`) clickable button for a neutral status row (`C.s1`/`C.txtS`) + a subtle secondary button. Uses existing palette tokens only.
- No data/logic change — same `setShowDetailed(true)` behavior, just a clearer UI.

## Testing
- `npm run build` passes (75 modules, no errors).
- 👉 **Vercel Preview:** open the auto-generated Preview deployment below to see it live. Go to **Mon profil** → the completed-questionnaire state shows the new button. (Preview uses localStorage only unless Supabase preview vars are set, so no real data is touched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)