### PR TITLE
fix(#9): Ressources complémentaires — real source URLs via Brave Search

### DIFF
--- a/api/resources.js
+++ b/api/resources.js
@@ -1,0 +1,71 @@
+// Resources endpoint: real web resources (with URLs) via the Brave Search API.
+// Env var needed: BRAVE_API_KEY (free tier at https://brave.com/search/api).
+// If the key is missing or Brave errors, this returns an empty result set and the
+// client falls back to curated deep-links, so the feature never hard-fails.
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed', results: [] })
+  }
+
+  var key = process.env.BRAVE_API_KEY || ''
+  if (!key) {
+    // Signal to the client to use its curated fallback (not an error the user should see).
+    return res.status(200).json({ error: 'NO_BRAVE_KEY', results: [] })
+  }
+
+  try {
+    var body = req.body || {}
+    var structure = (body.structure || '').toString().trim()
+    var targetLang = (body.targetLang || '').toString().trim()
+
+    if (!structure) {
+      return res.status(400).json({ error: 'No structure provided', results: [] })
+    }
+
+    // Query aimed at pedagogical explanations rather than raw target-language pages.
+    var query = structure + ' ' + targetLang + ' grammar meaning usage explanation'
+    var params = new URLSearchParams({
+      q: query,
+      count: '10',
+      safesearch: 'moderate',
+      text_decorations: 'false',
+    })
+
+    var r = await fetch('https://api.search.brave.com/res/v1/web/search?' + params.toString(), {
+      headers: {
+        'Accept': 'application/json',
+        'Accept-Encoding': 'gzip',
+        'X-Subscription-Token': key,
+      },
+    })
+    var raw = await r.text()
+
+    if (!r.ok) {
+      var msg = 'Brave ' + r.status
+      try {
+        var ej = JSON.parse(raw)
+        msg = (ej.error && (ej.error.detail || ej.error.message)) || ej.message || msg
+      } catch (e) {
+        msg = 'Brave ' + r.status + ': ' + raw.substring(0, 200)
+      }
+      // Still 200 to the client with empty results -> graceful curated fallback,
+      // but include the reason for debugging.
+      return res.status(200).json({ error: msg, results: [] })
+    }
+
+    var data = JSON.parse(raw)
+    var web = (data.web && data.web.results) || []
+    var results = web.slice(0, 6).map(function (it) {
+      return {
+        title: (it.title || it.url || '').replace(/<[^>]*>/g, ''),
+        uri: it.url,
+        snippet: (it.description || '').replace(/<[^>]*>/g, ''),
+      }
+    }).filter(function (it) { return it.uri })
+
+    return res.status(200).json({ results: results })
+  } catch (err) {
+    return res.status(200).json({ error: err.message, results: [] })
+  }
+}

--- a/api/resources.js
+++ b/api/resources.js
@@ -56,13 +56,19 @@ export default async function handler(req, res) {
 
     var data = JSON.parse(raw)
     var web = (data.web && data.web.results) || []
-    var results = web.slice(0, 6).map(function (it) {
+    var mapped = web.map(function (it) {
       return {
         title: (it.title || it.url || '').replace(/<[^>]*>/g, ''),
         uri: it.url,
         snippet: (it.description || '').replace(/<[^>]*>/g, ''),
       }
     }).filter(function (it) { return it.uri })
+
+    // Surface How To Study Korean first when it shows up — it's usually the most relevant.
+    function isHtsk(it) { return /howtostudykorean\.com/i.test(it.uri) }
+    mapped.sort(function (a, b) { return (isHtsk(b) ? 1 : 0) - (isHtsk(a) ? 1 : 0) })
+
+    var results = mapped.slice(0, 3)
 
     return res.status(200).json({ results: results })
   } catch (err) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -681,68 +681,79 @@ Return JSON: {"message": "your response"} or {"message": "your response", "optio
   return parseJSON((await callAI(sys, `Conversation so far:\n${hist}`)).text);
 }
 
+// Curated deep-links: each opens a trusted resource site pre-filtered to this
+// structure (not a generic Google search). Used as a fallback when web search
+// is unavailable. Language-aware, with a sensible generic set for other langs.
 function resourceSearchLinks(card, tlCode) {
   const structure = card.korean.trim();
+  const q = encodeURIComponent(structure);
   const target = getTargetLangName(tlCode, "en");
-  const searches = [
-    [`Google - ${target} grammar`, `${structure} ${target} grammar`],
-    [`YouTube - ${target} lesson`, `${structure} ${target} grammar lesson`],
-    [`Reddit - ${target} learners`, `${structure} ${target} grammar`],
-    [`HiNative - ${target}`, `${structure} ${target}`],
+  const ytQ = encodeURIComponent(`${structure} ${target} grammar lesson`);
+  const rdQ = encodeURIComponent(`${structure} ${target} grammar`);
+
+  const common = [
+    { title: `YouTube — leçon ${target}`, uri: `https://www.youtube.com/results?search_query=${ytQ}` },
+    { title: `Reddit — apprenants ${target}`, uri: `https://www.reddit.com/search/?q=${rdQ}` },
+    { title: "Wiktionary", uri: `https://en.wiktionary.org/w/index.php?search=${q}` },
   ];
-  return searches.map(([title, query]) => ({
-    title,
-    uri: `https://www.google.com/search?q=${encodeURIComponent(query)}${title.startsWith("YouTube") ? "+site%3Ayoutube.com" : title.startsWith("Reddit") ? "+site%3Areddit.com" : title.startsWith("HiNative") ? "+site%3Ahinative.com" : ""}`,
-  }));
+
+  const byLang = {
+    ko: [
+      { title: "How To Study Korean", uri: `https://www.howtostudykorean.com/?s=${q}` },
+      { title: "Talk To Me In Korean", uri: `https://talktomeinkorean.com/?s=${q}` },
+      { title: "Naver 국어사전", uri: `https://ko.dict.naver.com/#/search?query=${q}` },
+      { title: "HiNative", uri: `https://hinative.com/search?query=${q}` },
+    ],
+    de: [
+      { title: "Lingolia Deutsch", uri: `https://deutsch.lingolia.com/?s=${q}` },
+      { title: "DW Deutsch lernen", uri: `https://www.dw.com/search/?languageCode=de&item=${q}` },
+      { title: "HiNative", uri: `https://hinative.com/search?query=${q}` },
+    ],
+  };
+
+  return [...(byLang[tlCode] || []), ...common];
 }
 
+// Call the Brave-backed /api/resources route. Always resolves to { results: [...] }.
+async function callResources(structure, targetLangName, uiLang) {
+  const res = await fetch("/api/resources", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ structure, targetLang: targetLangName, uiLang }),
+  });
+  const raw = await res.text();
+  let data;
+  try { data = JSON.parse(raw); } catch { return { results: [] }; }
+  return data && Array.isArray(data.results) ? data : { results: [] };
+}
+
+// "Ressources complémentaires": real web resources (with URLs) via Brave Search.
+// Falls back to curated deep-links when the Brave key is missing or search fails,
+// so the button always returns useful, clickable sources — never an error.
 async function findResources(card, lang, tlCode) {
-  const L = lang === "fr" ? "French" : "English";
   const TL = getTargetLangName(tlCode, "en");
-  const sys = `You are a ${TL} language learning research assistant. Search the web for high-quality pedagogical resources explaining the grammar structure "${card.korean}".
+  const structure = card.korean.trim();
 
-TASK: Find 4-6 real, published resources that explain or demonstrate this specific structure. Return a useful mix when available: pedagogical lesson pages or teacher-created worksheets, grammar reference articles, relevant YouTube videos, and thoughtful discussions on HiNative, Reddit, or language-learning forums.
-
-PRIORITIZE:
-- Pages that explain the rule, its conjugation, and its nuances
-- Teacher-created lessons and worksheets with substantial explanations or examples
-- Videos and forum discussions that add a different practical perspective
-- Resources in ${L} or English when available, but include target-language resources if they are the best explanation
-
-For each resource, give:
-- The site or page name
-- A one-line description of what it covers and why it is useful
-- The URL
-
-Then add a short note in ${L} comparing what the different resources emphasize, so the student knows which to read or watch first.
-
-Write your answer in ${L}, in clear prose with line breaks. Do NOT return JSON. Do NOT invent URLs: only cite pages you actually found in your search.`;
-
-  const fallbackSys = `You are a ${TL} language learning assistant. The student wants pedagogical resources explaining the grammar structure "${card.korean}".
-
-You do NOT have web access right now, so do NOT invent URLs.
-
-Instead, in ${L}:
-1. Name 3-4 well-established reference sites you genuinely know cover ${TL} grammar (e.g. for Korean: How To Study Korean, Talk To Me In Korean, Naver 국어사전; for German: Deutsche Welle, Lingolia, Canoonet).
-2. For each, give the EXACT search terms the student should type to land on the right page (e.g. site name + the structure in quotes).
-3. Add a 2-3 sentence summary of the rule itself so the student has something useful right now.
-
-Be explicit that these are search suggestions, not direct links.
-
-Write plain readable prose with line breaks. Do NOT return JSON, do NOT use curly braces or key-value pairs.`;
+  const curatedFallback = () => {
+    const note = lang === "fr"
+      ? `Voici une sélection de ressources fiables pour « ${structure} ». Chaque lien ouvre directement le site correspondant, ciblé sur cette structure :`
+      : `Here's a selection of trusted resources for "${structure}". Each link opens the relevant site directly, targeted to this structure:`;
+    return { text: note, sources: resourceSearchLinks(card, tlCode) };
+  };
 
   try {
-    const r = await callAI(sys, `Find pedagogical resources explaining the ${TL} grammar structure: ${card.korean}`, 1600, true);
-    return { ...r, text: flattenIfJSON(r.text) };
-  } catch (e) {
-    if (String(e.message).includes("SEARCH_QUOTA")) {
-      const r = await callAI(fallbackSys, `Suggest how to find resources for: ${card.korean}`, 1200, false, true);
-      const fallbackNotice = lang === "fr"
-        ? "La recherche web Google est temporairement indisponible. Voici des recherches ciblées pour trouver des ressources actuelles :"
-        : "Google web search is temporarily unavailable. Here are targeted searches to find current resources:";
-      return { text: `${fallbackNotice}\n\n${flattenIfJSON(r.text)}`, sources: resourceSearchLinks(card, tlCode), degraded: true };
+    const data = await callResources(structure, TL, lang);
+    const results = (data.results || []).filter((r) => r && r.uri);
+    if (results.length) {
+      const intro = lang === "fr"
+        ? `Ressources trouvées sur le web pour « ${structure} ». Clique sur un lien ci-dessous pour l'ouvrir :`
+        : `Web resources found for "${structure}". Click any link below to open it:`;
+      return { text: intro, sources: results };
     }
-    throw e;
+    return curatedFallback();
+  } catch (e) {
+    console.error("findResources error:", e);
+    return curatedFallback();
   }
 }
 
@@ -1112,11 +1123,16 @@ function Bubble({ msg, revealAll }) {
             <div style={{ fontSize: 10, fontWeight: 600, color: C.txtM, textTransform: "uppercase", marginBottom: 5 }}>Sources</div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
               {msg.sources.map((s, i) => (
-                <a key={i} href={s.uri} target="_blank" rel="noopener noreferrer"
-                  style={{ fontSize: 11, color: C.acc, textDecoration: "none", display: "flex", alignItems: "center", gap: 4, lineHeight: 1.4 }}>
-                  <span style={{ flexShrink: 0 }}>🔗</span>
-                  <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{s.title}</span>
-                </a>
+                <div key={i} style={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                  <a href={s.uri} target="_blank" rel="noopener noreferrer"
+                    style={{ fontSize: 11, color: C.acc, textDecoration: "none", display: "flex", alignItems: "center", gap: 4, lineHeight: 1.4 }}>
+                    <span style={{ flexShrink: 0 }}>🔗</span>
+                    <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{s.title}</span>
+                  </a>
+                  {s.snippet && (
+                    <span style={{ fontSize: 10, color: C.txtS, lineHeight: 1.45, marginLeft: 18, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{s.snippet}</span>
+                  )}
+                </div>
               ))}
             </div>
           </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -711,7 +711,8 @@ function resourceSearchLinks(card, tlCode) {
     ],
   };
 
-  return [...(byLang[tlCode] || []), ...common];
+  // Cap at 3, language-specific sites first (How To Study Korean already leads the ko list).
+  return [...(byLang[tlCode] || []), ...common].slice(0, 3);
 }
 
 // Call the Brave-backed /api/resources route. Always resolves to { results: [...] }.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1112,7 +1112,7 @@ function Bubble({ msg, revealAll }) {
       <div style={{ width: 24, height: 24, borderRadius: "50%", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 11, flexShrink: 0, background: C.s1, border: `1px solid ${C.border}`, color: C.txtM }}>
         {ai ? "✦" : "🧑"}
       </div>
-      <div style={{ padding: "9px 12px", borderRadius: ai ? "2px 12px 12px 12px" : "12px 2px 12px 12px", fontSize: 12.5, lineHeight: 1.7, whiteSpace: "pre-wrap", background: ai ? C.s2 : C.acc, border: ai ? `1px solid ${C.border}` : "none", color: ai ? C.txt : C.onAcc }}>
+      <div style={{ minWidth: 0, padding: "9px 12px", borderRadius: ai ? "2px 12px 12px 12px" : "12px 2px 12px 12px", fontSize: 12.5, lineHeight: 1.7, whiteSpace: "pre-wrap", background: ai ? C.s2 : C.acc, border: ai ? `1px solid ${C.border}` : "none", color: ai ? C.txt : C.onAcc }}>
         {msg.degraded && (
           <div style={{ marginBottom: 8, padding: "6px 9px", background: C.warnBg, border: `1px solid ${C.warnB}`, borderRadius: 6, fontSize: 10.5, color: C.warn, lineHeight: 1.5 }}>
             ⚠️ Recherche web temporairement indisponible. Des liens de recherche ciblés sont proposés ci-dessous.
@@ -1124,11 +1124,11 @@ function Bubble({ msg, revealAll }) {
             <div style={{ fontSize: 10, fontWeight: 600, color: C.txtM, textTransform: "uppercase", marginBottom: 5 }}>Sources</div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
               {msg.sources.map((s, i) => (
-                <div key={i} style={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                <div key={i} style={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>
                   <a href={s.uri} target="_blank" rel="noopener noreferrer"
-                    style={{ fontSize: 11, color: C.acc, textDecoration: "none", display: "flex", alignItems: "center", gap: 4, lineHeight: 1.4 }}>
+                    style={{ fontSize: 11, color: C.acc, textDecoration: "none", display: "flex", alignItems: "center", gap: 4, lineHeight: 1.4, minWidth: 0, maxWidth: "100%" }}>
                     <span style={{ flexShrink: 0 }}>🔗</span>
-                    <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{s.title}</span>
+                    <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{s.title}</span>
                   </a>
                   {s.snippet && (
                     <span style={{ fontSize: 10, color: C.txtS, lineHeight: 1.45, marginLeft: 18, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{s.snippet}</span>

--- a/vite.config.js
+++ b/vite.config.js
@@ -83,12 +83,53 @@ function devApiProxy() {
   }
 }
 
+function devResourcesProxy() {
+  let braveKey = ''
+  return {
+    name: 'dev-resources-proxy',
+    configResolved() { braveKey = process.env.BRAVE_API_KEY || '' },
+    configureServer(server) {
+      server.middlewares.use('/api/resources', async (req, res) => {
+        const send = (code, obj) => { res.writeHead(code, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(obj)) }
+        if (req.method !== 'POST') { res.writeHead(405); res.end('Method not allowed'); return }
+        if (!braveKey) return send(200, { error: 'NO_BRAVE_KEY', results: [] })
+        let body = ''
+        for await (const chunk of req) body += chunk
+        try {
+          const { structure = '', targetLang = '' } = JSON.parse(body || '{}')
+          if (!String(structure).trim()) return send(400, { error: 'No structure provided', results: [] })
+          const params = new URLSearchParams({
+            q: `${structure} ${targetLang} grammar meaning usage explanation`,
+            count: '10', safesearch: 'moderate', text_decorations: 'false',
+          })
+          const r = await fetch('https://api.search.brave.com/res/v1/web/search?' + params.toString(), {
+            headers: { 'Accept': 'application/json', 'Accept-Encoding': 'gzip', 'X-Subscription-Token': braveKey },
+          })
+          const raw = await r.text()
+          if (!r.ok) return send(200, { error: 'Brave ' + r.status + ': ' + raw.substring(0, 200), results: [] })
+          const data = JSON.parse(raw)
+          const web = (data.web && data.web.results) || []
+          const results = web.slice(0, 6).map(it => ({
+            title: (it.title || it.url || '').replace(/<[^>]*>/g, ''),
+            uri: it.url,
+            snippet: (it.description || '').replace(/<[^>]*>/g, ''),
+          })).filter(it => it.uri)
+          return send(200, { results })
+        } catch (e) {
+          return send(200, { error: e.message, results: [] })
+        }
+      })
+    },
+  }
+}
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   process.env.AI_API_KEY = env.AI_API_KEY || ''
   process.env.AI_PROVIDER = env.AI_PROVIDER || 'gemini'
+  process.env.BRAVE_API_KEY = env.BRAVE_API_KEY || ''
   return {
-    plugins: [react(), devApiProxy()],
+    plugins: [react(), devApiProxy(), devResourcesProxy()],
     server: { port: 3000, open: true },
   }
 })


### PR DESCRIPTION
Closes #9.

## The bug
"Ressources complémentaires" relied on **Gemini's Google Search grounding** to find source URLs. That grounding is a **paid/quota-limited** feature — on the free tier every call returns **HTTP 429 SEARCH_QUOTA**, so the button failed every time. (Confirmed by hitting the live API: plain calls return 200, grounded calls return 429.) The old fallback only produced generic `google.com/search` links.

## The fix
- **`api/resources.js`** (new): fetches real resources — title, URL, snippet — from the **Brave Search API** (free tier, ~2,000 queries/month). Missing key or any error → empty results, so the client falls back gracefully. Never hard-fails.
- **`findResources()`**: now calls `/api/resources` and renders real, clickable sources. Falls back to **curated, language-aware deep-links** (How To Study Korean, TTMIK, Naver 국어사전, HiNative, YouTube, Reddit, Wiktionary) pre-targeted to the grammar structure — no more generic Google links.
- Removed the Gemini-grounding path and the misleading "recherche temporairement indisponible" banner for this feature.
- Each source now shows a 2-line snippet.
- Added a matching `/api/resources` **dev proxy** in `vite.config.js` for local parity.

## Setup required for real results
Add **`BRAVE_API_KEY`** in Vercel (Preview + Production). Get a free key at https://brave.com/search/api. **Until the key is added, the button still works** — it shows the curated deep-links instead of erroring.

## Testing
- `npm run build` passes.
- Dev `/api/resources` returns `{error:"NO_BRAVE_KEY",results:[]}` (HTTP 200) with no key → confirms graceful fallback.
- Real Brave results verifiable on the Preview once the key is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)